### PR TITLE
Suggestion for version flag in binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TARGET ?= darwin
 ARCH ?= amd64
 EXT ?= ""
 DOCKER_REPO=itsdalmo/ssm-sh
+TRAVIS_TAG ?= ref-$(shell git rev-parse --short HEAD)
 SRC=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: test
@@ -40,6 +41,6 @@ build-docker:
 
 build-release:
 	@echo "== Release build =="
-	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build -o $(BINARY_NAME)-$(TARGET)-$(ARCH)$(EXT) -v
+	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build -ldflags "-X main.version=$(TRAVIS_TAG)" -o $(BINARY_NAME)-$(TARGET)-$(ARCH)$(EXT) -v
 
 .PHONY: default build test build-docker run-docker build-release

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ ARCH ?= amd64
 EXT ?= ""
 DOCKER_REPO=itsdalmo/ssm-sh
 TRAVIS_TAG ?= ref-$(shell git rev-parse --short HEAD)
+LDFLAGS=-ldflags "-X=main.Version=$(TRAVIS_TAG)"
 SRC=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: test
 
 run: test
 	@echo "== Run =="
-	go run main.go
+	go run $(LDFLAGS) main.go
 
 build: test
 	@echo "== Build =="
@@ -41,6 +42,6 @@ build-docker:
 
 build-release:
 	@echo "== Release build =="
-	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build -ldflags "-X main.version=$(TRAVIS_TAG)" -o $(BINARY_NAME)-$(TARGET)-$(ARCH)$(EXT) -v
+	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build $(LDFLAGS) -o $(BINARY_NAME)-$(TARGET)-$(ARCH)$(EXT) -v
 
 .PHONY: default build test build-docker run-docker build-release

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARCH ?= amd64
 EXT ?= ""
 DOCKER_REPO=itsdalmo/ssm-sh
 TRAVIS_TAG ?= ref-$(shell git rev-parse --short HEAD)
-LDFLAGS=-ldflags "-X=main.Version=$(TRAVIS_TAG)"
+LDFLAGS=-ldflags "-X=main.version=$(TRAVIS_TAG)"
 SRC=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: test
@@ -15,7 +15,7 @@ run: test
 
 build: test
 	@echo "== Build =="
-	go build -o $(BINARY_NAME) -v
+	go build -o $(BINARY_NAME) -v $(LDFLAGS)
 
 test:
 	@echo "== Test =="

--- a/command/root.go
+++ b/command/root.go
@@ -3,6 +3,7 @@ package command
 var Command RootCommand
 
 type RootCommand struct {
+	Version func()       `short:"v" long:"version" description:"Print the version and exit."`
 	List    ListCommand  `command:"list" alias:"ls" description:"List managed instances."`
 	Shell   ShellCommand `command:"shell" alias:"sh" description:"Start an interactive shell."`
 	Run     RunCommand   `command:"run" description:"Run a command on the targeted instances."`

--- a/command/version.go
+++ b/command/version.go
@@ -1,0 +1,16 @@
+package command
+
+import (
+	"fmt"
+	"os"
+)
+
+// CommandVersion (overridden in main.go)
+var CommandVersion string
+
+func init() {
+	Command.Version = func() {
+		fmt.Println(CommandVersion)
+		os.Exit(0)
+	}
+}

--- a/command/version.go
+++ b/command/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // CommandVersion (overridden in main.go)
-var CommandVersion string
+var CommandVersion = "unknown"
 
 func init() {
 	Command.Version = func() {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,11 @@ import (
 	"os"
 )
 
+// Version is set on build by the Git release tag.
+var version string
+
 func main() {
+	command.CommandVersion = version
 	_, err := flags.Parse(&command.Command)
 	if err != nil {
 		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {


### PR DESCRIPTION
The intention here is that we use `-ldflags` to set the `version` variable when compiling the binary - this should set the version to be whatever the `TRAVIS_TAG` is when it's being built for a release (releases are triggered on tags), and locally, it sets the version to be `ref-<short git sha>`.

Open to feedback on this :)