### PR TITLE
Fixed version command to output unknown if not set

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -5,8 +5,8 @@ import (
 	"os"
 )
 
-// CommandVersion (overridden in main.go)
-var CommandVersion = "unknown"
+// CommandVersion (set from main.go)
+var CommandVersion string
 
 func init() {
 	Command.Version = func() {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Version is set on build by the Git release tag.
-var version string
+var version = "unknown"
 
 func main() {
 	command.CommandVersion = version


### PR DESCRIPTION
Since main.go always overrides CommandVersion it will always be empty if not set. This change makes sure its set to unknown if not specified.