### PR TITLE
Support S3 bucket and key for run/shell output

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -2,11 +2,12 @@ package command
 
 import (
 	"encoding/json"
-	"github.com/itsdalmo/ssm-sh/manager"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/itsdalmo/ssm-sh/manager"
+	"github.com/pkg/errors"
 )
 
 type ListCommand struct {
@@ -20,7 +21,7 @@ func (command *ListCommand) Execute([]string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create new session")
 	}
-	m := manager.NewManager(sess, Command.AwsOpts.Region)
+	m := manager.NewManager(sess, Command.AwsOpts.Region, manager.Opts{})
 
 	var filters []*manager.TagFilter
 	for _, tag := range command.Tags {

--- a/command/run.go
+++ b/command/run.go
@@ -3,15 +3,17 @@ package command
 import (
 	"context"
 	"fmt"
-	"github.com/itsdalmo/ssm-sh/manager"
-	"github.com/pkg/errors"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/itsdalmo/ssm-sh/manager"
+	"github.com/pkg/errors"
 )
 
 type RunCommand struct {
-	Timeout    int `short:"i" long:"timeout" description:"Seconds to wait for command result before timing out." default:"30"`
+	Timeout    int        `short:"i" long:"timeout" description:"Seconds to wait for command result before timing out." default:"30"`
+	SSMOpts    SSMOptions `group:"SSM options"`
 	TargetOpts TargetOptions
 }
 
@@ -21,7 +23,11 @@ func (command *RunCommand) Execute(args []string) error {
 		return errors.Wrap(err, "failed to create new aws session")
 	}
 
-	m := manager.NewManager(sess, Command.AwsOpts.Region)
+	opts, err := command.SSMOpts.Parse()
+	if err != nil {
+		return err
+	}
+	m := manager.NewManager(sess, Command.AwsOpts.Region, *opts)
 	targets, err := setTargets(command.TargetOpts)
 	if err != nil {
 		return errors.Wrap(err, "failed to set targets")

--- a/command/shell.go
+++ b/command/shell.go
@@ -3,15 +3,17 @@ package command
 import (
 	"context"
 	"fmt"
-	"github.com/chzyer/readline"
-	"github.com/itsdalmo/ssm-sh/manager"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/itsdalmo/ssm-sh/manager"
+	"github.com/pkg/errors"
 )
 
 type ShellCommand struct {
+	SSMOpts    SSMOptions `group:"SSM options"`
 	TargetOpts TargetOptions
 }
 
@@ -21,7 +23,11 @@ func (command *ShellCommand) Execute([]string) error {
 		return errors.Wrap(err, "failed to create new aws session")
 	}
 
-	m := manager.NewManager(sess, Command.AwsOpts.Region)
+	opts, err := command.SSMOpts.Parse()
+	if err != nil {
+		return err
+	}
+	m := manager.NewManager(sess, Command.AwsOpts.Region, *opts)
 	targets, err := setTargets(command.TargetOpts)
 	if err != nil {
 		return errors.Wrap(err, "failed to set targets")

--- a/command/ssm_opts.go
+++ b/command/ssm_opts.go
@@ -1,0 +1,32 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/itsdalmo/ssm-sh/manager"
+)
+
+type SSMOptions struct {
+	ExtendOutput bool   `short:"x" long:"extend-output" description:"Extend truncated command outputs by fetching S3 objects containing full ones"`
+	S3Bucket     string `short:"b" long:"s3-bucket" description:"S3 bucket in which S3 objects containing full command outputs are stored. Required when --extend-output is provided." default:""`
+	S3KeyPrefix  string `short:"k" long:"s3-key-prefix" description:"Key prefix of S3 objects containing full command outputs." default:""`
+}
+
+func (o SSMOptions) Validate() error {
+	if o.ExtendOutput && o.S3Bucket == "" {
+		return fmt.Errorf("--s3-bucket must be a non-empty string when --extend-output is provided")
+	}
+	return nil
+}
+
+func (o SSMOptions) Parse() (*manager.Opts, error) {
+	err := o.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return &manager.Opts{
+		ExtendOutput: o.ExtendOutput,
+		S3Bucket:     o.S3Bucket,
+		S3KeyPrefix:  o.S3KeyPrefix,
+	}, nil
+}

--- a/command/utils.go
+++ b/command/utils.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/fatih/color"
-	"github.com/itsdalmo/ssm-sh/manager"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,6 +11,10 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/fatih/color"
+	"github.com/itsdalmo/ssm-sh/manager"
 )
 
 // Create a new AWS session
@@ -102,6 +103,11 @@ func PrintCommandOutput(wrt io.Writer, output *manager.CommandOutput) error {
 	}
 	if _, err := fmt.Fprintf(wrt, "%s\n", output.Output); err != nil {
 		return err
+	}
+	if output.OutputUrl != "" {
+		if _, err := fmt.Fprintf(wrt, "(Output URL: %s)\n", output.OutputUrl); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/command/utils_test.go
+++ b/command/utils_test.go
@@ -3,12 +3,13 @@ package command_test
 import (
 	"bytes"
 	"errors"
-	"github.com/itsdalmo/ssm-sh/command"
-	"github.com/itsdalmo/ssm-sh/manager"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/itsdalmo/ssm-sh/command"
+	"github.com/itsdalmo/ssm-sh/manager"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrintInstances(t *testing.T) {
@@ -62,6 +63,13 @@ func TestPrintCommandOutput(t *testing.T) {
 			Error:      nil,
 		},
 		{
+			InstanceID: "i-00000000000000001",
+			Status:     "Success",
+			Output:     "Extended standard output",
+			OutputUrl:  "https://s3-ap-northeast-1.amazonaws.com/mybucket/foobar/c0896747-af2b-4359-bc34-0f951ce02007/i-00000000000000001/awsrunShellScript/0.awsrunShellScript/stdout",
+			Error:      nil,
+		},
+		{
 			InstanceID: "i-00000000000000002",
 			Status:     "Failed",
 			Output:     "Standard error",
@@ -79,6 +87,10 @@ func TestPrintCommandOutput(t *testing.T) {
 		expected := strings.TrimSpace(`
 i-00000000000000001 - Success:
 Standard output
+
+i-00000000000000001 - Success:
+Extended standard output
+(Output URL: https://s3-ap-northeast-1.amazonaws.com/mybucket/foobar/c0896747-af2b-4359-bc34-0f951ce02007/i-00000000000000001/awsrunShellScript/0.awsrunShellScript/stdout)
 
 i-00000000000000002 - Failed:
 Standard error

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/itsdalmo/ssm-sh/command"
 	"github.com/jessevdk/go-flags"
-	"os"
 )
 
 // Version is set on build by the Git release tag.


### PR DESCRIPTION
This adds three flags to the `run` and `shell` commands:

- `--extend-output`: Extend truncated command outputs by fetching S3 objects containing full ones
- `--s3-bucket`: S3 bucket in which S3 objects containing full command outputs are stored. Required when `--extend-output` is provided.
- `--s3-key-prefix`: Key prefix of S3 objects containing full command outputs.

Example usage:

Ensure your target EC2 instance to have an instance profile with an appropriate
IAM policy like [this](https://gist.github.com/mumoshu/653c3a8fba12838cf82c032dd70c3161).

And then run a `ssm-sh` command like:

```console
ssm-sh shell \
  --region ap-northeast-1 \
  --target i-0717d725ae0219bc6 \
  --extend-output \
  --s3-bucket mybucket \
  --s3-key-prefix foobar
```

On the shell, running a command whose output is huge enough to be truncated results in a S3 object like:

```
https://s3-ap-northeast-1.amazonaws.com/mybucket/foobar/c0896747-af2b-4359-bc34-0f951ce02007/i-0717d725ae0219bc6/awsrunShellScript/0.awsrunShellScript/stdout
```

whereas `c0896747-af2b-4359-bc34-0f951ce02007` is the `Command ID` of the command.

You can also do `ssm-sh run` instead of `shell` with an exactly same set of flags to
achieve the same result for oneshot command runs.

Resolves #7

~~This is WIP until I finish manual testing :wink:~~ Done.