### PR TITLE
Refactor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ which ssm-sh
 $ ssm-sh --help
 
 Usage:
-  main [OPTIONS] <command>
+  ssm-sh [OPTIONS] <command>
 
 Application Options:
   -v, --version  Print the version and exit.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ which ssm-sh
 $ ssm-sh --help
 
 Usage:
-  ssm-sh [OPTIONS] <list | run | shell>
+  main [OPTIONS] <command>
+
+Application Options:
+  -v, --version  Print the version and exit.
 
 AWS Options:
   -p, --profile= AWS Profile to use. (If you are not using Vaulted).
@@ -57,31 +60,61 @@ Help Options:
   -h, --help     Show this help message
 
 Available commands:
-  list   List managed instances. (aliases: ls)
-  run    Run a command on the targeted instances.
-  shell  Start an interactive shell. (aliases: sh)
+  describe  Description a document from ssm.
+  list      List managed instances or documents. (aliases: ls)
+  run       Run a command or document on the targeted instances.
+  shell     Start an interactive shell. (aliases: sh)
 ```
 
-#### List usage
+#### List instances usage
 
 ```bash
-$ ssm-sh list --help
+$ ssm-sh list instances --help
 
 ...
-[list command options]
+[instances command options]
       -f, --filter= Filter the produced list by tag (key=value,..)
       -l, --limit=  Limit the number of instances printed (default: 50)
       -o, --output= Path to a file where the list of instances will be written as JSON.
 ```
 
-#### Run/shell usage
-
+#### List documents usage
 ```bash
-$ ssm-sh run --help
+$ ssm-sh list documents --help
 
 ...
-[run command options]
+[documents command options]
+      -f, --filter= Filter the produced list by property (Name, Owner, DocumentType, PlatformTypes)
+      -l, --limit=  Limit the number of instances printed (default: 50)
+```
+
+#### Run cmd/shell usage
+
+```bash
+$ ssm-sh run cmd --help
+
+...
+[cmd command options]
       -i, --timeout=       Seconds to wait for command result before timing out. (default: 30)
+      -t, --target=        One or more instance ids to target
+          --target-file=   Path to a JSON file containing a list of targets.
+
+    SSM options:
+      -x, --extend-output  Extend truncated command outputs by fetching S3 objects containing full ones
+      -b, --s3-bucket=     S3 bucket in which S3 objects containing full command outputs are stored. Required when --extend-output is provided.
+      -k, --s3-key-prefix= Key prefix of S3 objects containing full command outputs.
+```
+
+#### Run document usage
+
+```bash
+$ ssm-sh run document --help
+
+...
+[document command options]
+      -n, --name=          Name of document in ssm.
+      -i, --timeout=       Seconds to wait for command result before timing out. (default: 30)
+      -p, --parameter=     Zero or more parameters for the document (name:value)
       -t, --target=        One or more instance ids to target
           --target-file=   Path to a JSON file containing a list of targets.
 
@@ -94,7 +127,7 @@ $ ssm-sh run --help
 ## Example
 
 ```bash
-$ vaulted -n lab-admin -- ssm-sh list --filter Name="*itsdalmo" -o example.json
+$ vaulted -n lab-admin -- ssm-sh list instances --filter Name="*itsdalmo" -o example.json
 
 Instance ID         | Name                             | State   | Image ID     | Platform     | Version | IP            | Status | Last pinged
 i-03762678c45546813 | ssm-manager-manual-test-itsdalmo | running | ami-db1688a2 | Amazon Linux | 2.0     | 172.53.17.163 | Online | 2018-02-09 12:37

--- a/command/list-instances.go
+++ b/command/list-instances.go
@@ -10,13 +10,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-type ListCommand struct {
+type ListInstancesCommand struct {
 	Tags   []*tag `short:"f" long:"filter" description:"Filter the produced list by tag (key=value,..)"`
 	Limit  int64  `short:"l" long:"limit" description:"Limit the number of instances printed" default:"50"`
 	Output string `short:"o" long:"output" description:"Path to a file where the list of instances will be written as JSON."`
 }
 
-func (command *ListCommand) Execute([]string) error {
+func (command *ListInstancesCommand) Execute([]string) error {
 	sess, err := newSession()
 	if err != nil {
 		return errors.Wrap(err, "failed to create new session")

--- a/command/root.go
+++ b/command/root.go
@@ -12,17 +12,17 @@ type RootCommand struct {
 }
 
 type ListCommand struct {
-	Instances ListInstancesCommand `command:"instances" alias:"i" description:"List managed instances."`
-	Documents ListDocumentsCommand `command:"documents" alias:"d" description:"List managed documents."`
+	Instances ListInstancesCommand `command:"instances" alias:"ins" description:"List managed instances."`
+	Documents ListDocumentsCommand `command:"documents" alias:"doc" description:"List managed documents."`
 }
 
 type RunCommand struct {
-	RunCmd      RunCmdCommand      `command:"cmd" alias:"c" description:"Run a command on the targeted instances."`
-	RunDocument RunDocumentCommand `command:"document" alias:"d" description:"Runs a document from ssm."`
+	RunCmd      RunCmdCommand      `command:"command" alias:"cmd" description:"Run a command on the targeted instances."`
+	RunDocument RunDocumentCommand `command:"document" alias:"doc" description:"Runs a document from ssm."`
 }
 
 type DescribeCommand struct {
-	Describe DescribeDocumentCommand `command:"document" alias:"d" description:"Description a document from ssm."`
+	Describe DescribeDocumentCommand `command:"document" alias:"doc" description:"Description a document from ssm."`
 }
 
 type AwsOptions struct {

--- a/command/root.go
+++ b/command/root.go
@@ -3,14 +3,26 @@ package command
 var Command RootCommand
 
 type RootCommand struct {
-	Version          func()                  `short:"v" long:"version" description:"Print the version and exit."`
-	List             ListCommand             `command:"list" alias:"ls" description:"List managed instances."`
-	Shell            ShellCommand            `command:"shell" alias:"sh" description:"Start an interactive shell."`
-	Run              RunCommand              `command:"run" description:"Run a command on the targeted instances."`
-	ListDocuments    ListDocumentsCommand    `command:"list-documents" alias:"ld" description:"List available documents in ssm."`
-	RunDocument      RunDocumentCommand      `command:"run-document" description:"Runs a document from ssm."`
-	DescribeDocument DescribeDocumentCommand `command:"describe-document" description:"Description a document from ssm."`
-	AwsOpts          AwsOptions              `group:"AWS Options"`
+	Version  func()          `short:"v" long:"version" description:"Print the version and exit."`
+	List     ListCommand     `command:"list" alias:"ls" description:"List managed instances or documents."`
+	Shell    ShellCommand    `command:"shell" alias:"sh" description:"Start an interactive shell."`
+	Run      RunCommand      `command:"run" description:"Run a command or document on the targeted instances."`
+	Describe DescribeCommand `command:"describe" description:"Description a document from ssm."`
+	AwsOpts  AwsOptions      `group:"AWS Options"`
+}
+
+type ListCommand struct {
+	Instances ListInstancesCommand `command:"instances" alias:"i" description:"List managed instances."`
+	Documents ListDocumentsCommand `command:"documents" alias:"d" description:"List managed documents."`
+}
+
+type RunCommand struct {
+	RunCmd      RunCmdCommand      `command:"cmd" alias:"c" description:"Run a command on the targeted instances."`
+	RunDocument RunDocumentCommand `command:"document" alias:"d" description:"Runs a document from ssm."`
+}
+
+type DescribeCommand struct {
+	Describe DescribeDocumentCommand `command:"document" alias:"d" description:"Description a document from ssm."`
 }
 
 type AwsOptions struct {

--- a/command/run-cmd.go
+++ b/command/run-cmd.go
@@ -35,7 +35,8 @@ func (command *RunCmdCommand) Execute(args []string) error {
 	fmt.Printf("Use ctrl-c to abort the command early.\n\n")
 
 	// Start the command
-	commandID, err := m.RunCommand(targets, strings.Join(args, " "))
+	cmd := strings.Join(args, " ")
+	commandID, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": cmd})
 	if err != nil {
 		return errors.Wrap(err, "failed to run command")
 	}

--- a/command/run-cmd.go
+++ b/command/run-cmd.go
@@ -11,13 +11,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-type RunCommand struct {
+type RunCmdCommand struct {
 	Timeout    int        `short:"i" long:"timeout" description:"Seconds to wait for command result before timing out." default:"30"`
 	SSMOpts    SSMOptions `group:"SSM options"`
 	TargetOpts TargetOptions
 }
 
-func (command *RunCommand) Execute(args []string) error {
+func (command *RunCmdCommand) Execute(args []string) error {
 	sess, err := newSession()
 	if err != nil {
 		return errors.Wrap(err, "failed to create new aws session")

--- a/command/run-document.go
+++ b/command/run-document.go
@@ -14,6 +14,7 @@ type RunDocumentCommand struct {
 	Name       string            `short:"n" long:"name" description:"Name of document in ssm."`
 	Timeout    int               `short:"i" long:"timeout" description:"Seconds to wait for command result before timing out." default:"30"`
 	Parameters map[string]string `short:"p" long:"parameter" description:"Zero or more parameters for the document (name:value)"`
+	SSMOpts    SSMOptions        `group:"SSM options"`
 	TargetOpts TargetOptions
 }
 
@@ -28,7 +29,11 @@ func (command *RunDocumentCommand) Execute(args []string) error {
 		return errors.Wrap(err, "failed to create new aws session")
 	}
 
-	m := manager.NewManager(sess, Command.AwsOpts.Region, manager.Opts{})
+	opts, err := command.SSMOpts.Parse()
+	if err != nil {
+		return err
+	}
+	m := manager.NewManager(sess, Command.AwsOpts.Region, *opts)
 	targets, err := setTargets(command.TargetOpts)
 	if err != nil {
 		return errors.Wrap(err, "failed to set targets")

--- a/command/run-document.go
+++ b/command/run-document.go
@@ -36,7 +36,7 @@ func (command *RunDocumentCommand) Execute(args []string) error {
 	fmt.Printf("Use ctrl-c to abort the command early.\n\n")
 
 	// Start the command
-	commandID, err := m.RunDocument(targets, command.Name, command.Parameters)
+	commandID, err := m.RunCommand(targets, command.Name, command.Parameters)
 	if err != nil {
 		return errors.Wrap(err, "failed to run command")
 	}

--- a/command/shell.go
+++ b/command/shell.go
@@ -71,7 +71,7 @@ func (command *ShellCommand) Execute([]string) error {
 		}
 
 		// Start command
-		commandID, err := m.RunCommand(targets, cmd)
+		commandID, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": cmd})
 		if err != nil {
 			return errors.Wrap(err, "failed to Run command")
 		}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -208,29 +208,7 @@ func (m *Manager) describeInstances(instances []*ssm.InstanceInformation, tagFil
 }
 
 // RunCommand on the given instance ids.
-func (m *Manager) RunCommand(instanceIds []string, command string) (string, error) {
-	input := &ssm.SendCommandInput{
-		InstanceIds:  aws.StringSlice(instanceIds),
-		DocumentName: aws.String("AWS-RunShellScript"),
-		Comment:      aws.String("Interactive command."),
-		Parameters:   map[string][]*string{"commands": {aws.String(command)}},
-	}
-	if m.s3Bucket != "" {
-		input.OutputS3BucketName = aws.String(m.s3Bucket)
-	}
-	if m.s3KeyPrefix != "" {
-		input.OutputS3KeyPrefix = aws.String(m.s3KeyPrefix)
-	}
-	res, err := m.ssmClient.SendCommand(input)
-	if err != nil {
-		return "", err
-	}
-
-	return aws.StringValue(res.Command.CommandId), nil
-}
-
-// RunDocument on the given instance ids.
-func (m *Manager) RunDocument(instanceIds []string, name string, parameters map[string]string) (string, error) {
+func (m *Manager) RunCommand(instanceIds []string, name string, parameters map[string]string) (string, error) {
 
 	var params map[string][]*string
 
@@ -247,7 +225,12 @@ func (m *Manager) RunDocument(instanceIds []string, name string, parameters map[
 		Comment:      aws.String("Document triggered through ssm-sh."),
 		Parameters:   params,
 	}
-
+	if m.s3Bucket != "" {
+		input.OutputS3BucketName = aws.String(m.s3Bucket)
+	}
+	if m.s3KeyPrefix != "" {
+		input.OutputS3KeyPrefix = aws.String(m.s3KeyPrefix)
+	}
 	res, err := m.ssmClient.SendCommand(input)
 	if err != nil {
 		return "", err

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -383,7 +383,7 @@ func TestRunCommand(t *testing.T) {
 
 	t.Run("Run works", func(t *testing.T) {
 		expected := "command-1"
-		actual, err := m.RunCommand(targets, "ls -la")
+		actual, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.Nil(t, err)
 		assert.NotNil(t, actual)
 		assert.Equal(t, expected, actual)
@@ -395,16 +395,12 @@ func TestRunCommand(t *testing.T) {
 			ssmMock.Error = false
 		}()
 
-		actual, err := m.RunCommand(targets, "ls -la")
+		actual, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "expected")
 		assert.Equal(t, "", actual)
 	})
 }
-
-/*
-func TestRunDocumentCommand(t *testing.T) {
-}*/
 
 func TestAbortCommand(t *testing.T) {
 	ssmMock := &manager.MockSSM{
@@ -433,14 +429,14 @@ func TestAbortCommand(t *testing.T) {
 	}
 
 	t.Run("Abort works", func(t *testing.T) {
-		id, err := m.RunCommand(targets, "ls -la")
+		id, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.Nil(t, err)
 		err = m.AbortCommand(targets, id)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Invalid command id errors are propagated", func(t *testing.T) {
-		_, err := m.RunCommand(targets, "ls -la")
+		_, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.Nil(t, err)
 		err = m.AbortCommand(targets, "invalid")
 		assert.NotNil(t, err)
@@ -486,7 +482,7 @@ func TestOutput(t *testing.T) {
 	}
 
 	t.Run("Get output works with standard out", func(t *testing.T) {
-		id, err := m.RunCommand(targets, "ls -la")
+		id, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.Nil(t, err)
 
 		ctx := context.Background()
@@ -510,7 +506,7 @@ func TestOutput(t *testing.T) {
 			ssmMock.CommandStatus = "Success"
 		}()
 
-		id, err := m.RunCommand(targets, "ls -la")
+		id, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.Nil(t, err)
 
 		ctx := context.Background()
@@ -525,7 +521,7 @@ func TestOutput(t *testing.T) {
 	})
 
 	t.Run("Get output is aborted if the context is done", func(t *testing.T) {
-		id, err := m.RunCommand(targets, "ls -la")
+		id, err := m.RunCommand(targets, "AWS-RunShellScript", map[string]string{"commands": "ls -la"})
 		assert.Nil(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Refactored the command to use `object verb`, also merged `RunCommand` and `RunDocument` since they where basically duplicated functions.