### PR TITLE
allow using region from current session

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -27,7 +27,7 @@ type DescribeCommand struct {
 
 type AwsOptions struct {
 	Profile string `short:"p" long:"profile" description:"AWS Profile to use. (If you are not using Vaulted)."`
-	Region  string `short:"r" long:"region" description:"Region to target." default:"eu-west-1"`
+	Region  string `short:"r" long:"region" description:"Region to target."`
 }
 
 type TargetOptions struct {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -63,7 +63,10 @@ type Opts struct {
 
 // NewManager creates a new Manager from an AWS session and region.
 func NewManager(sess *session.Session, region string, opts Opts) *Manager {
-	awsCfg := &aws.Config{Region: aws.String(region)}
+	awsCfg := &aws.Config{}
+	if region != "" {
+		awsCfg.Region = aws.String(region)
+	}
 	m := &Manager{
 		ssmClient: ssm.New(sess, awsCfg),
 		s3Client:  s3.New(sess, awsCfg),


### PR DESCRIPTION
This allows omitting the `--region` parameter when region is set in current session.