### PR TITLE
Fix certificate error in Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV ARCH amd64
 RUN make build-release
 
 FROM alpine
-COPY --from=builder /go/src/github.com/itsdalmo/ssm-sh/ssm-sh-linux-amd64 /bin/ssm-sh
+RUN apk --no-cache add ca-certificates
 ENTRYPOINT ["/bin/ssm-sh"]
 CMD ["--help"]
+COPY --from=builder /go/src/github.com/itsdalmo/ssm-sh/ssm-sh-linux-amd64 /bin/ssm-sh


### PR DESCRIPTION
When running `list instances`, I would receive an error `Post
https://ssm.us-west-2.amazonaws.com/: x509: failed to load system roots and no
roots provided`. Adding `ca-certificates` into the image resolves this issue.

I also reordered the directives for the final image to reuse layers. The layers
are minimal so you won't notice, but it's a good habit.