### PR TITLE
Revert "Fix version in docker"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM golang:1.10 as builder
-MAINTAINER itsdalmo
+
 ADD . /go/src/github.com/itsdalmo/ssm-sh
 WORKDIR /go/src/github.com/itsdalmo/ssm-sh
-ENV TARGET linux
-ENV ARCH amd64
+ARG TARGET=linux
+ARG ARCH=amd64
 RUN make build-release
 
-FROM alpine
+FROM alpine:latest as resource
+COPY --from=builder /go/src/github.com/itsdalmo/ssm-sh/ssm-sh-linux-amd64 /bin/ssm-sh
 RUN apk --no-cache add ca-certificates
 ENTRYPOINT ["/bin/ssm-sh"]
 CMD ["--help"]
-COPY --from=builder /go/src/github.com/itsdalmo/ssm-sh/ssm-sh-linux-amd64 /bin/ssm-sh
+
+FROM resource

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
 FROM golang:1.10 as builder
-
+MAINTAINER itsdalmo
 ADD . /go/src/github.com/itsdalmo/ssm-sh
 WORKDIR /go/src/github.com/itsdalmo/ssm-sh
-ARG TARGET=linux
-ARG ARCH=amd64
-ARG CACHE_TAG
+ENV TARGET linux
+ENV ARCH amd64
 RUN make build-release
 
-FROM alpine:latest as resource
-COPY --from=builder /go/src/github.com/itsdalmo/ssm-sh/ssm-sh-linux-amd64 /bin/ssm-sh
+FROM alpine
 RUN apk --no-cache add ca-certificates
 ENTRYPOINT ["/bin/ssm-sh"]
 CMD ["--help"]
-
-FROM resource
+COPY --from=builder /go/src/github.com/itsdalmo/ssm-sh/ssm-sh-linux-amd64 /bin/ssm-sh

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,11 @@
-BINARY_NAME = ssm-sh
-DOCKER_REPO = itsdalmo/ssm-sh
-TARGET     ?= darwin
-ARCH       ?= amd64
-EXT        ?= ""
-
-GIT_REF = $(shell git rev-parse --short HEAD)
-GIT_TAG = $(if $(TRAVIS_TAG),$(TRAVIS_TAG),$(if $(CACHE_TAG),$(CACHE_TAG),ref-$(GIT_REF)))
-
-LDFLAGS = -ldflags "-X=main.version=$(GIT_TAG)"
-SRC     = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+BINARY_NAME=ssm-sh
+TARGET ?= darwin
+ARCH ?= amd64
+EXT ?= ""
+DOCKER_REPO=itsdalmo/ssm-sh
+TRAVIS_TAG ?= ref-$(shell git rev-parse --short HEAD)
+LDFLAGS=-ldflags "-X=main.version=$(TRAVIS_TAG)"
+SRC=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: test
 
@@ -28,7 +25,7 @@ test:
 
 clean:
 	@echo "== Cleaning =="
-	@rm -f ssm-sh* || true
+	rm ssm-sh*
 
 lint:
 	@echo "== Lint =="
@@ -41,7 +38,7 @@ run-docker:
 
 build-docker:
 	@echo "== Docker build =="
-	docker build --build-arg CACHE_TAG=$(GIT_TAG) -t $(DOCKER_REPO):latest .
+	docker build -t $(DOCKER_REPO):latest .
 
 build-release: test
 	@echo "== Release build =="

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-BINARY_NAME=ssm-sh
-TARGET ?= darwin
-ARCH ?= amd64
-EXT ?= ""
-DOCKER_REPO=itsdalmo/ssm-sh
-TRAVIS_TAG ?= ref-$(shell git rev-parse --short HEAD)
-LDFLAGS=-ldflags "-X=main.version=$(TRAVIS_TAG)"
-SRC=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
+BINARY_NAME = ssm-sh
+DOCKER_REPO = itsdalmo/ssm-sh
+TARGET     ?= darwin
+ARCH       ?= amd64
+EXT        ?= ""
+
+GIT_REF = $(shell git rev-parse --short HEAD)
+GIT_TAG = $(if $(TRAVIS_TAG),$(TRAVIS_TAG),ref-$(GIT_REF))
+
+LDFLAGS = -ldflags "-X=main.version=$(GIT_TAG)"
+SRC     = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: test
 
@@ -25,7 +28,7 @@ test:
 
 clean:
 	@echo "== Cleaning =="
-	rm ssm-sh*
+	@rm -f ssm-sh* || true
 
 lint:
 	@echo "== Lint =="


### PR DESCRIPTION
Reverts itsdalmo/ssm-sh#23

So, the fix did not fix anything because the environment variables are only available to build hooks:
https://forums.docker.com/t/docker-cloud-build-environment-variables-not-being-passed-to-the-auto-build/24010/10

I'm thinking I don't want to introduce hooks and other complexities to the repo when the images themselves are already tagged correctly. In addition, CACHE_TAG would resolve to `latest` (I believe) for docker images with the latest tag. I.e., I think it's better to revert these changes and stick with what we have.