### PR TITLE
Bump Go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ env:
 matrix:
   include:
   - os: osx
-    go: 1.11.x
+    go: 1.13.x
     env:
       - TARGET=darwin
       - ARCH=amd64
   - os: linux
-    go: 1.11.x
+    go: 1.13.x
     env:
       - TARGET=linux
       - ARCH=amd64
   - os: linux
-    go: 1.11.x
+    go: 1.13.x
     env:
       - TARGET=windows
       - ARCH=amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as builder
+FROM golang:1.13 as builder
 
 ADD . /go/src/github.com/itsdalmo/ssm-sh
 WORKDIR /go/src/github.com/itsdalmo/ssm-sh

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc // indirect
 	golang.org/x/text v0.3.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Latest release is old and built with 1.11. Lets bump for good measure.